### PR TITLE
Fix(personal-info): Enhance NID data extraction and loading

### DIFF
--- a/src/accountOpening/PersonalInfoPage.js
+++ b/src/accountOpening/PersonalInfoPage.js
@@ -94,6 +94,23 @@ const PersonalInfoPage_EN = () => {
                 }
 
                 if (nidResp && Object.keys(nidResp).length) {
+                    if (!updated.firstNameAr && nidResp.fullNameArabic) {
+                        const arabicNameParts = (nidResp.fullNameArabic || '').trim().split(/\s+/);
+                        updated.firstNameAr = arabicNameParts[0] || '';
+                        updated.middleNameAr = arabicNameParts[1] || '';
+                        updated.lastNameAr = arabicNameParts[2] || '';
+                        updated.surnameAr = arabicNameParts.length > 3 ? arabicNameParts.slice(3).join(' ') : '';
+                    }
+                    if (!updated.firstNameEn && nidResp.givenNameEng) {
+                        const engNameParts = (nidResp.givenNameEng || '').trim().split(/\s+/);
+                        updated.firstNameEn = engNameParts[0] || '';
+                        updated.middleNameEn = engNameParts[1] || '';
+                        updated.lastNameEn = engNameParts[2] || '';
+                    }
+                    if (!updated.surnameEn && nidResp.surnameEng) {
+                        updated.surnameEn = nidResp.surnameEng || '';
+                    }
+
                     updated.nidDigits = nidResp.nationalId ? nidResp.nationalId.replace(/\D/g, '').slice(0, 12).split('') : Array(12).fill('');
                     if (!updated.gender) {
                       updated.gender = nidResp.sex === 'M' ? 'male' : nidResp.sex === 'F' ? 'female' : (nidResp.sex || '');
@@ -103,9 +120,9 @@ const PersonalInfoPage_EN = () => {
                             ? `${nidResp.birthYear}-${nidResp.birthMonth.toString().padStart(2,'0')}-${nidResp.birthDay.toString().padStart(2,'0')}`
                             : '';
                     }
-                    updated.familyRecordNumber = nidResp.familyId || '';
-                    updated.motherFullName = nidResp.motherFullName || '';
-                    updated.maritalStatus = nidResp.maritalStatus || '';
+                    if (!updated.familyRecordNumber) updated.familyRecordNumber = nidResp.familyId || '';
+                    if (!updated.motherFullName) updated.motherFullName = nidResp.motherFullName || '';
+                    if (!updated.maritalStatus) updated.maritalStatus = nidResp.maritalStatus || '';
                 }
 
                 setForm(updated);

--- a/src/utils/fieldMapper.js
+++ b/src/utils/fieldMapper.js
@@ -23,6 +23,9 @@ export function mapPassportFields(data = {}) {
 export function mapNIDFields(data = {}) {
   if (!data || typeof data !== 'object') return data;
   const fieldMap = {
+    'Full Name (Arabic)': 'fullNameArabic',
+    'Given Name (English)': 'givenNameEng',
+    'Surname (English)': 'surnameEng',
     'Family Record Number': 'familyId',
     'National ID': 'nationalId',
     'Sex': 'sex',

--- a/src/utils/passportNidExtractors.js
+++ b/src/utils/passportNidExtractors.js
@@ -29,6 +29,9 @@ const passportSchema = {
 const nidSchema = {
   type: 'OBJECT',
   properties: {
+    fullNameArabic: { type: 'STRING' },
+    givenNameEng: { type: 'STRING' },
+    surnameEng: { type: 'STRING' },
     familyId: { type: 'STRING' },
     nationalId: { type: 'STRING' },
     sex: { type: 'STRING' },
@@ -127,7 +130,7 @@ export async function extractPassportData(file, provider = 'gemini') {
 
 export async function extractNIDData(file, provider = 'gemini') {
   const base64Data = await fileToBase64(file);
-  const prompt = 'Extract the following fields from the NID document image: Family Record Number (\u0631\u0642\u0645 \u0642\u064a\u062f \u0627\u0644\u0639\u0627\u0626\u0644\u0629), National ID (\u0627\u0644\u0631\u0642\u0645 \u0627\u0644\u0648\u0637\u0646\u064a), Sex (\u0627\u0644\u062c\u0646\u0633), Day of Birth, Month of Birth, Year of Birth, Mother\'s Full Name, and Marital Status. If any field is unclear, leave it blank and do not guess. Return the data in the specified JSON format.';
+  const prompt = 'Extract the following fields from the NID document image: Full Name (Arabic), Given Name (English), Surname (English), Family Record Number (\u0631\u0642\u0645 \u0642\u064a\u062f \u0627\u0644\u0639\u0627\u0626\u0644\u0629), National ID (\u0627\u0644\u0631\u0642\u0645 \u0627\u0644\u0648\u0637\u0646\u064a), Sex (\u0627\u0644\u062c\u0646\u0633), Day of Birth, Month of Birth, Year of Birth, Mother\'s Full Name, and Marital Status. If any field is unclear, leave it blank and do not guess. Return the data in the specified JSON format.';
   if (provider === 'chatgpt') {
     return callChatGPT(prompt, base64Data, file.type || 'image/png');
   } else if (provider === 'tesseract') {


### PR DESCRIPTION
This commit enhances the data extraction process for National ID (NID) documents and improves the way this data is loaded into the personal information form.

The key changes are:

- The NID extraction schema and prompt have been updated to include Arabic and English name fields.
- The field mapper for NID data has been updated to correctly map the new name fields.
- The personal information page now intelligently merges data from both passport and NID scans. It prioritizes passport data but uses NID data as a fallback for any missing fields, preventing existing data from being overwritten.

These changes ensure that the personal information form is populated with the most complete and accurate data available from the user's documents.