### PR TITLE
fix: Initialize otpStore to prevent ReferenceError

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -130,7 +130,7 @@ app.post('/api/save-selfie', async (req, res) => {
 });
 
 
-
+const otpStore = {};
 
 
 


### PR DESCRIPTION
The `otpStore` variable was being used in the OTP routes without being declared, causing a `ReferenceError`.

This change initializes `otpStore` as an empty object in `backend/server.js` to serve as an in-memory store for OTPs, resolving the error.