### PR TITLE
feat: Use real API at NID validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,5 +37,13 @@ BRANCH_DATE_API_TOKEN=
 BANK_ACC_API_URL=http://10.1.100.204/Account_Statment/API/createBankAccount.php
 BANK_ACC_API_TOKEN=
 
+# SSO Configuration
+SSO_URL=https://sso.ndb.gov.ly/connect/token
+SSO_CLIENT_ID=clientid-NDB
+SSO_CLIENT_SECRET=clientsecret-NDB
+SSO_SCOPE=nid phone
+
+# NID Configuration
+NID_API_URL=https://nid.ndb.gov.ly
 
 

--- a/NID_VALIDATION.md
+++ b/NID_VALIDATION.md
@@ -1,0 +1,65 @@
+# NID Validation API
+
+This document describes how to use the NID (National ID) validation API.
+
+## Environment Variables
+
+The following environment variables must be set in your `.env` file:
+
+```
+# SSO Configuration
+SSO_URL=https://sso.ndb.gov.ly/connect/token
+SSO_CLIENT_ID=clientid-NDB
+SSO_CLIENT_SECRET=clientsecret-NDB
+SSO_SCOPE=nid phone
+
+# NID Configuration
+NID_API_URL=https://nid.ndb.gov.ly
+```
+
+## API Endpoints
+
+### POST /api/nid/validate
+
+This endpoint validates a National ID.
+
+**Request Body:**
+
+```json
+{
+  "nid": "119830000000"
+}
+```
+
+**Response:**
+
+The response from this endpoint is the direct response from the NID validation API.
+
+### GET /api/nid/state
+
+This endpoint checks the state of the NID service.
+
+**Response:**
+
+The response from this endpoint is the direct response from the NID state API.
+
+### POST /api/nid/phone/match
+
+This endpoint checks if a phone number is matching with a National ID.
+
+**Request Body:**
+
+```json
+{
+  "nid": "119000000000",
+  "phone": "920000000"
+}
+```
+
+**Response:**
+
+```json
+{
+  "isMatching": true
+}
+```

--- a/backend/routes/nid.js
+++ b/backend/routes/nid.js
@@ -1,0 +1,45 @@
+const express = require('express');
+const router = express.Router();
+const { getSsoToken, validateNid, checkNidState, isPhoneMatching } = require('../services/nidService');
+
+router.post('/validate', async (req, res) => {
+  const { nid } = req.body;
+  if (!nid) {
+    return res.status(400).json({ error: 'NID is required' });
+  }
+
+  try {
+    const token = await getSsoToken();
+    const validationResult = await validateNid(nid, token);
+    res.json(validationResult);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.get('/state', async (req, res) => {
+    try {
+        const token = await getSsoToken();
+        const state = await checkNidState(token);
+        res.json(state);
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+});
+
+router.post('/phone/match', async (req, res) => {
+    const { nid, phone } = req.body;
+    if (!nid || !phone) {
+        return res.status(400).json({ error: 'NID and phone are required' });
+    }
+
+    try {
+        const token = await getSsoToken();
+        const matchResult = await isPhoneMatching(nid, phone, token);
+        res.json(matchResult);
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -68,6 +68,7 @@ require('dotenv').config();
 const { logActivity, logError, logEmailDebug } = require('./utils/logger');
 const { sanitize } = require('./utils/sanitizer');
 const { isAuthenticated } = require('./middleware/auth');
+const nidRoutes = require('./routes/nid');
 
 const https = require('https');
 const http = require('http');
@@ -1042,6 +1043,8 @@ app.post('/api/work-validation', async (req, res) => {
     res.status(500).json({ error: 'server_error' });
   }
 });
+
+app.use('/api/nid', nidRoutes);
 
 app.use((err, req, res, next) => {
   logError(`ERROR ${err.message}`);

--- a/backend/services/nidService.js
+++ b/backend/services/nidService.js
@@ -1,0 +1,71 @@
+const axios = require('axios');
+
+const getSsoToken = async () => {
+  try {
+    const response = await axios.post(process.env.SSO_URL, new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: process.env.SSO_CLIENT_ID,
+      client_secret: process.env.SSO_CLIENT_SECRET,
+      scope: process.env.SSO_SCOPE
+    }), {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
+    });
+    return response.data.access_token;
+  } catch (error) {
+    console.error('Error fetching SSO token:', error.response ? error.response.data : error.message);
+    throw new Error('Failed to fetch SSO token');
+  }
+};
+
+const validateNid = async (nid, token) => {
+  try {
+    const response = await axios.post(`${process.env.NID_API_URL}/search/byNid`, { nid }, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      }
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error validating NID:', error.response ? error.response.data : error.message);
+    throw new Error('Failed to validate NID');
+  }
+};
+
+const checkNidState = async (token) => {
+    try {
+        const response = await axios.get(`${process.env.NID_API_URL}/state`, {
+            headers: {
+                'Authorization': `Bearer ${token}`
+            }
+        });
+        return response.data;
+    } catch (error) {
+        console.error('Error checking NID state:', error.response ? error.response.data : error.message);
+        throw new Error('Failed to check NID state');
+    }
+};
+
+const isPhoneMatching = async (nid, phone, token) => {
+    try {
+        const response = await axios.post(`${process.env.NID_API_URL}/ismatching`, { nid, phone }, {
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
+            }
+        });
+        return response.data;
+    } catch (error) {
+        console.error('Error checking if phone is matching:', error.response ? error.response.data : error.message);
+        throw new Error('Failed to check if phone is matching');
+    }
+};
+
+module.exports = {
+  getSsoToken,
+  validateNid,
+  checkNidState,
+  isPhoneMatching
+};


### PR DESCRIPTION
This commit implements NID validation using the real API.

It introduces the following changes:

- Adds SSO and NID API configuration to `.env.example`.
- Creates a new `nidService` to handle interactions with the SSO and NID APIs.
- Creates a new `/api/nid` route for NID validation.
- Integrates the new route into the main server file.
- Adds documentation for the new NID validation feature.