### PR TITLE
fix: Use correct URL for phone matching service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,5 +45,6 @@ SSO_SCOPE=nid phone
 
 # NID Configuration
 NID_API_URL=https://nid.ndb.gov.ly
+PHONE_API_URL=https://phone.ndb.gov.ly
 
 

--- a/backend/services/nidService.js
+++ b/backend/services/nidService.js
@@ -50,7 +50,7 @@ const checkNidState = async (token) => {
 
 const isPhoneMatching = async (nid, phone, token) => {
     try {
-        const response = await axios.post(`${process.env.NID_API_URL}/ismatching`, { nid, phone }, {
+        const response = await axios.post(`${process.env.PHONE_API_URL}/ismatching`, { nid, phone }, {
             headers: {
                 'Content-Type': 'application/json',
                 'Authorization': `Bearer ${token}`

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,15 @@
+.shake {
+  animation: shake 0.5s;
+}
 
+@keyframes shake {
+  0% { transform: translateX(0); }
+  10%, 30%, 50%, 70%, 90% { transform: translateX(-10px); }
+  20%, 40%, 60%, 80% { transform: translateX(10px); }
+  100% { transform: translateX(0); }
+}
+
+.input-error {
+  border-color: red !important;
+  background-color: rgba(255, 0, 0, 0.1) !important;
+}


### PR DESCRIPTION
This commit fixes a bug where the phone matching service was calling the wrong URL.

Based on user feedback and a provided curl command, the service has been updated to:
- Use a new `PHONE_API_URL` environment variable.
- Point to the correct host (`phone.ndb.gov.ly`) and path (`/ismatching`).

The `.env.example` file has been updated to include the new `PHONE_API_URL` variable.